### PR TITLE
Rename environment variable to SAKURACLOUD_KMS_KEY_ID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The tool automatically:
 
 ### Wrapper Mode (Primary Use Case)
 The tool operates as a SOPS wrapper via `RunWrapper()` function:
-- Reads `SAKURA_KMS_KEY_ID` environment variable (12-digit Sakura Cloud resource ID as string)
+- Reads `SAKURACLOUD_KMS_KEY_ID` environment variable (12-digit Sakura Cloud resource ID as string)
 - Validates that `--hc-vault-transit` is not manually specified (returns error if it is)
 - Starts HTTP server on `127.0.0.1:8200` in background
 - Waits for server health check (30 retries × 100ms)
@@ -108,7 +108,7 @@ SOPS does not support passing `--hc-vault-transit` via environment variables. Th
 1. Command-line flag: `--hc-vault-transit <uri>`
 2. Configuration file: `.sops.yaml` with `hc_vault_transit_uri`
 
-Since we need dynamic configuration based on `SAKURA_KMS_KEY_ID`, the wrapper approach automatically injects the flag.
+Since we need dynamic configuration based on `SAKURACLOUD_KMS_KEY_ID`, the wrapper approach automatically injects the flag.
 
 ### Why Prevent Manual `--hc-vault-transit`?
 If users manually specify `--hc-vault-transit`, it conflicts with the wrapper's automatic configuration. The tool explicitly checks for this and returns an error to prevent confusion.
@@ -122,7 +122,7 @@ If users manually specify `--hc-vault-transit`, it conflicts with the wrapper's 
 ### Constants
 - `VaultPrefix = "vault:v1:"` - Required by SOPS for Vault Transit Engine compatibility
 - `KeyIDPathParam = "key_id"` - URL path parameter name
-- `EnvKeyID = "SAKURA_KMS_KEY_ID"` - Environment variable for KMS resource ID
+- `EnvKeyID = "SAKURACLOUD_KMS_KEY_ID"` - Environment variable for KMS resource ID
 - `ServerAddr = "127.0.0.1:8200"` - Standard Vault server address (localhost only)
 
 ## Go Version

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ export SAKURACLOUD_ACCESS_TOKEN="your-access-token"
 export SAKURACLOUD_ACCESS_TOKEN_SECRET="your-access-token-secret"
 
 # Sakura Cloud KMS Resource ID (12-digit number as string, e.g., 123456789012)
-export SAKURA_KMS_KEY_ID="123456789012"
+export SAKURACLOUD_KMS_KEY_ID="123456789012"
 ```
 
 ## Usage

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 const (
 	VaultPrefix    = "vault:v1:"
 	KeyIDPathParam = "key_id"
-	EnvKeyID       = "SAKURA_KMS_KEY_ID"
+	EnvKeyID       = "SAKURACLOUD_KMS_KEY_ID"
 	ServerAddr     = "127.0.0.1:8200"
 )
 

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestRunWrapper_WithoutKeyID(t *testing.T) {
-	// Ensure SAKURA_KMS_KEY_ID is not set
+	// Ensure SAKURACLOUD_KMS_KEY_ID is not set
 	os.Unsetenv(ssk.EnvKeyID)
 
 	err := ssk.RunWrapper(context.Background(), []string{"--version"})
 	if err == nil {
-		t.Error("expected error when SAKURA_KMS_KEY_ID is not set, got nil")
+		t.Error("expected error when SAKURACLOUD_KMS_KEY_ID is not set, got nil")
 	}
 
 	expectedMsg := ssk.EnvKeyID + " environment variable is required"
@@ -24,7 +24,7 @@ func TestRunWrapper_WithoutKeyID(t *testing.T) {
 }
 
 func TestRunWrapper_WithHcVaultTransitArg(t *testing.T) {
-	// Set SAKURA_KMS_KEY_ID for this test
+	// Set SAKURACLOUD_KMS_KEY_ID for this test
 	os.Setenv(ssk.EnvKeyID, "test-key")
 	defer os.Unsetenv(ssk.EnvKeyID)
 


### PR DESCRIPTION
## Summary

Rename the environment variable from `SAKURA_KMS_KEY_ID` to `SAKURACLOUD_KMS_KEY_ID` for consistency with other Sakura Cloud environment variables.

## Changes

- Update `EnvKeyID` constant in main.go
- Update all documentation in README.md
- Update architecture documentation in CLAUDE.md
- Update test comments in wrapper_test.go

## Rationale

This change maintains naming consistency with other Sakura Cloud environment variables:
- `SAKURACLOUD_ACCESS_TOKEN`
- `SAKURACLOUD_ACCESS_TOKEN_SECRET`
- `SAKURACLOUD_KMS_KEY_ID` (new)

All Sakura Cloud-related environment variables now use the `SAKURACLOUD_` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)