### PR TITLE
Use SOPS_VAULT_URIS environment variable instead of --hc-vault-transit flag

### DIFF
--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -22,37 +22,3 @@ func TestRunWrapper_WithoutKeyID(t *testing.T) {
 		t.Errorf("error message = %q, want %q", err.Error(), expectedMsg)
 	}
 }
-
-func TestRunWrapper_WithHcVaultTransitArg(t *testing.T) {
-	// Set SAKURACLOUD_KMS_KEY_ID for this test
-	os.Setenv(ssk.EnvKeyID, "test-key")
-	defer os.Unsetenv(ssk.EnvKeyID)
-
-	tests := []struct {
-		name string
-		args []string
-	}{
-		{
-			name: "with --hc-vault-transit flag",
-			args: []string{"--hc-vault-transit", "http://example.com/v1/transit/keys/my-key", "test.yaml"},
-		},
-		{
-			name: "with --hc-vault-transit= format",
-			args: []string{"--hc-vault-transit=http://example.com/v1/transit/keys/my-key", "test.yaml"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ssk.RunWrapper(context.Background(), tt.args)
-			if err == nil {
-				t.Error("expected error when --hc-vault-transit is specified, got nil")
-			}
-
-			expectedMsg := "--hc-vault-transit should not be specified when using this wrapper; it will be set automatically from " + ssk.EnvKeyID
-			if err.Error() != expectedMsg {
-				t.Errorf("error message = %q, want %q", err.Error(), expectedMsg)
-			}
-		})
-	}
-}


### PR DESCRIPTION
## Summary
- Replace `--hc-vault-transit` command-line flag with `SOPS_VAULT_URIS` environment variable
- Avoid argument ordering issues when executing SOPS
- Simplify code by removing flag conflict detection

## Changes
- Set `SOPS_VAULT_URIS` environment variable instead of injecting `--hc-vault-transit` flag
- Remove `--hc-vault-transit` conflict validation code
- Remove related test cases
- Update documentation (CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)