### PR TITLE
Add --version flag support

### DIFF
--- a/cmd/sops-sakura-kms/main.go
+++ b/cmd/sops-sakura-kms/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -19,5 +20,15 @@ func main() {
 }
 
 func run(ctx context.Context) error {
-	return app.RunWrapper(ctx, os.Args[1:])
+	args := os.Args[1:]
+
+	// Handle --version flag
+	for _, arg := range args {
+		if arg == "--version" || arg == "-version" {
+			fmt.Printf("sops-sakura-kms version %s\n", app.Version)
+			return nil
+		}
+	}
+
+	return app.RunWrapper(ctx, args)
 }


### PR DESCRIPTION
## Summary
Add support for `--version` and `-version` flags to display the tool version.

## Changes
- Add version flag handling in `cmd/sops-sakura-kms/main.go`
- Display version information from the auto-updated `version.go` file
- All other arguments continue to be passed through to SOPS

## Usage
```bash
$ sops-sakura-kms --version
sops-sakura-kms version v0.0.2

$ sops-sakura-kms -version
sops-sakura-kms version v0.0.2
```

## Test results
All existing tests pass successfully.