### PR TITLE
build container images

### DIFF
--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -42,3 +42,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+        if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
+
+      - name: Docker Login
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and Push Docker Image
+        run: |
+          make image-push IMAGE_VERSION=${{ steps.tagpr.outputs.tag || github.event.inputs.tag || 'latest' }}
+        if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
         run: |
           make image-load
         env:
-          IMAGE_VERSION: test-$(date +%s)-${{ matrix.go }}
+          IMAGE_VERSION: test-${{ github.sha }}-${{ matrix.go }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,9 @@ jobs:
       - name: Build & Test
         run: |
           go test -race ./...
+
+      - name: Build image
+        run: |
+          make image-load
         env:
-          GO111MODULE: on
+          IMAGE_VERSION: test-$(date +%s)-${{ matrix.go }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM --platform=${BUILDPLATFORM} golang:1.25 AS build-env
+
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
+ENV CGO_ENABLED=0
+RUN mkdir -p /go/src/github.com/fujiwara/sops-sakura-kms
+COPY . /go/src/github.com/fujiwara/sops-sakura-kms
+WORKDIR /go/src/github.com/fujiwara/sops-sakura-kms
+RUN make clean && make
+
+FROM --platform=${BUILDPLATFORM} ghcr.io/getsops/sops:v3.11.0 AS sops
+
+FROM gcr.io/distroless/static-debian12
+LABEL maintainer="fujiwara <fujiwara.shunichiro@gmail.com>"
+
+COPY --from=build-env /go/src/github.com/fujiwara/sops-sakura-kms/sops-sakura-kms /usr/local/bin/sops-sakura-kms
+COPY --from=sops /usr/local/bin/sops /usr/local/bin/sops
+ENTRYPOINT ["/usr/local/bin/sops-sakura-kms"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: clean test
 
+IMAGE_VERSION ?= $(shell git describe --tags --abbrev)
+
 sops-sakura-kms: go.* *.go
 	go build -o $@ ./cmd/sops-sakura-kms
 
@@ -14,3 +16,17 @@ install:
 
 dist:
 	goreleaser build --snapshot --clean
+
+image-push: clean
+	go mod vendor
+	docker buildx build --platform linux/amd64,linux/arm64 \
+	-t ghcr.io/fujiwara/sops-sakura-kms:$(IMAGE_VERSION) \
+	--push \
+	-f Dockerfile .
+
+image-load: clean
+	go mod vendor
+	docker buildx build --platform linux/amd64 \
+	-t ghcr.io/fujiwara/sops-sakura-kms:$(IMAGE_VERSION) \
+	--load \
+	-f Dockerfile .

--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ jobs:
 
 This action sets up `sops-sakura-kms` and makes it available in the PATH. The `sops` command needs to be installed separately.
 
+### Container Image
+
+You can use the provided container image: [`ghcr.io/fujiwara/sops-sakura-kms`](https://github.com/fujiwara/sops-sakura-kms/pkgs/container/sops-sakura-kms).
+
+```console
+$ docker run --rm \
+    -e SAKURACLOUD_ACCESS_TOKEN \
+    -e SAKURACLOUD_ACCESS_TOKEN_SECRET \
+    -e SAKURACLOUD_KMS_KEY_ID \
+    -v $(pwd):/work -w /work \
+    ghcr.io/fujiwara/sops-sakura-kms:v0.0.5 \
+    -d secrets.enc.yaml
+```
+
+This image includes both `sops-sakura-kms` and `sops` commands.
+
 ## Prerequisites
 
 - [SOPS](https://github.com/getsops/sops) must be installed and available in your PATH


### PR DESCRIPTION
This pull request introduces automated multi-platform Docker image building and publishing for the project, along with supporting changes to the `Dockerfile` and `Makefile`. The workflow now sets up QEMU and Docker Buildx, logs into Docker Hub, and builds/pushes images based on tags or manual triggers. The `Dockerfile` has been refactored to support cross-platform builds, and new Makefile targets facilitate building and publishing images.

**CI/CD Workflow Improvements:**

* Added steps to the `.github/workflows/tagpr-release.yml` workflow to set up QEMU and Docker Buildx, log in to Docker Hub, and build/push Docker images automatically when a tag is present or on manual dispatch.

**Dockerfile Enhancements:**

* Refactored `Dockerfile` to support multi-architecture builds using Buildx, with build arguments for target OS/architecture, and staged builds for the main binary and SOPS integration.

**Makefile Additions:**

* Introduced the `IMAGE_VERSION` variable to dynamically set the image tag based on the current git tag.
* Added `image-push` target to build and push multi-platform images, and `image-load` target to build and load images locally for testing. Both targets use Buildx and the new Dockerfile.