### PR TITLE
Rename SSK_SOPS_PATH to SSK_COMMAND

### DIFF
--- a/env.go
+++ b/env.go
@@ -4,5 +4,5 @@ type Env struct {
 	KMSKeyID   string `env:"SAKURACLOUD_KMS_KEY_ID" required:""`
 	ServerOnly bool   `env:"SSK_SERVER_ONLY" default:"false"`
 	ServerAddr string `env:"SSK_SERVER_ADDR" default:"127.0.0.1:8200"`
-	SOPSPath   string `env:"SSK_SOPS_PATH" default:"sops"`
+	Command    string `env:"SSK_COMMAND" default:"sops"`
 }

--- a/env_test.go
+++ b/env_test.go
@@ -13,7 +13,7 @@ import (
 var envSet = map[string]string{
 	"SAKURACLOUD_KMS_KEY_ID": "example-key-id-2",
 	"SSK_SERVER_ADDR":        "192.168.0.1:8200",
-	"SSK_SOPS_PATH":          "/usr/local/bin/sops",
+	"SSK_COMMAND":            "/usr/local/bin/sops",
 	"SSK_SERVER_ONLY":        "true",
 }
 
@@ -30,7 +30,7 @@ func TestParseEnv(t *testing.T) {
 	serverOnly, _ := strconv.ParseBool(os.Getenv("SSK_SERVER_ONLY")) // default is false
 	if diff := cmp.Diff(ssk.Env{
 		ServerAddr: os.Getenv("SSK_SERVER_ADDR"),
-		SOPSPath:   os.Getenv("SSK_SOPS_PATH"),
+		Command:    os.Getenv("SSK_COMMAND"),
 		KMSKeyID:   os.Getenv("SAKURACLOUD_KMS_KEY_ID"),
 		ServerOnly: serverOnly,
 	}, e); diff != "" {
@@ -47,7 +47,7 @@ func TestParseEnvDefault(t *testing.T) {
 	k.Parse([]string{})
 	if diff := cmp.Diff(ssk.Env{
 		ServerAddr: "127.0.0.1:8200",
-		SOPSPath:   "sops",
+		Command:    "sops",
 		KMSKeyID:   os.Getenv("SAKURACLOUD_KMS_KEY_ID"),
 		ServerOnly: false,
 	}, e); diff != "" {

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func newServer(cipher Cipher, addr string) *http.Server {
 	return &http.Server{Addr: addr, Handler: mux}
 }
 
-// RunWrapper starts a Vault Transit Engine compatible API server and executes SOPS command.
+// RunWrapper starts a Vault Transit Engine compatible API server and executes a command.
 // It automatically configures SOPS to use Sakura Cloud KMS via SOPS_VAULT_URIS environment variable.
 // Requires SAKURA_KMS_KEY_ID environment variable to be set.
 func RunWrapper(ctx context.Context, args []string) error {
@@ -82,7 +82,7 @@ func RunWrapper(ctx context.Context, args []string) error {
 		return nil
 	}
 
-	slog.Info("Server started successfully, executing SOPS", "command", e.SOPSPath, "args", args)
+	slog.Info("Server started successfully, executing", "command", e.Command, "args", args)
 
 	// 4. Set environment variables for SOPS
 	vaultTransitURI := fmt.Sprintf("http://%s/v1/transit/encrypt/%s", e.ServerAddr, e.KMSKeyID)
@@ -92,8 +92,8 @@ func RunWrapper(ctx context.Context, args []string) error {
 		"SOPS_VAULT_URIS="+vaultTransitURI,
 	)
 
-	// 5. Execute SOPS command
-	cmd := exec.CommandContext(ctx, e.SOPSPath, args...)
+	// 5. Execute command
+	cmd := exec.CommandContext(ctx, e.Command, args...)
 	cmd.Env = env
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
## Summary
- Rename environment variable `SSK_SOPS_PATH` to `SSK_COMMAND` for more generic naming
- Allow executing commands other than sops (e.g., terraform)
- Add Terraform usage example to README

🤖 Generated with [Claude Code](https://claude.com/claude-code)