### PR TITLE
Replace kong with custom LoadEnv function

### DIFF
--- a/env.go
+++ b/env.go
@@ -1,8 +1,61 @@
 package ssk
 
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+)
+
 type Env struct {
 	KMSKeyID   string `env:"SAKURACLOUD_KMS_KEY_ID" required:""`
 	ServerOnly bool   `env:"SSK_SERVER_ONLY" default:"false"`
 	ServerAddr string `env:"SSK_SERVER_ADDR" default:"127.0.0.1:8200"`
 	Command    string `env:"SSK_COMMAND" default:"sops"`
+}
+
+// LoadEnv loads environment variables into an Env struct based on struct tags.
+// It reads the "env" tag for the environment variable name,
+// "default" tag for default values, and "required" tag for required fields.
+func LoadEnv() (*Env, error) {
+	env := &Env{}
+	v := reflect.ValueOf(env).Elem()
+	t := v.Type()
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		fieldValue := v.Field(i)
+
+		envName := field.Tag.Get("env")
+		if envName == "" {
+			continue
+		}
+
+		value := os.Getenv(envName)
+		if value == "" {
+			value = field.Tag.Get("default")
+		}
+
+		_, required := field.Tag.Lookup("required")
+		if required && value == "" {
+			return nil, fmt.Errorf("required environment variable %s is not set", envName)
+		}
+
+		switch fieldValue.Kind() {
+		case reflect.String:
+			fieldValue.SetString(value)
+		case reflect.Bool:
+			if value != "" {
+				b, err := strconv.ParseBool(value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid boolean value for %s: %w", envName, err)
+				}
+				fieldValue.SetBool(b)
+			}
+		default:
+			return nil, fmt.Errorf("unsupported field type: %s", fieldValue.Kind())
+		}
+	}
+
+	return env, nil
 }

--- a/env_test.go
+++ b/env_test.go
@@ -36,6 +36,7 @@ func TestParseEnv(t *testing.T) {
 }
 
 func TestParseEnvDefault(t *testing.T) {
+	t.Setenv("SAKURACLOUD_KMS_KEY_ID", "default-key-id")
 	e, err := ssk.LoadEnv()
 	if err != nil {
 		t.Fatalf("failed to load environment variables: %v", err)
@@ -47,6 +48,14 @@ func TestParseEnvDefault(t *testing.T) {
 		ServerOnly: false,
 	}, e); diff != "" {
 		t.Errorf("parsed env mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestParseEnvRequired(t *testing.T) {
+	t.Setenv("SAKURACLOUD_KMS_KEY_ID", "")
+	_, err := ssk.LoadEnv()
+	if err == nil {
+		t.Fatal("expected error for missing required field, got nil")
 	}
 }
 

--- a/env_test.go
+++ b/env_test.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/alecthomas/kong"
 	ssk "github.com/fujiwara/sops-sakura-kms"
 	"github.com/google/go-cmp/cmp"
 )
@@ -21,14 +20,12 @@ func TestParseEnv(t *testing.T) {
 	for k, v := range envSet {
 		t.Setenv(k, v)
 	}
-	var e ssk.Env
-	k, err := kong.New(&e)
+	e, err := ssk.LoadEnv()
 	if err != nil {
 		t.Fatalf("failed to create parser: %v", err)
 	}
-	k.Parse([]string{})
 	serverOnly, _ := strconv.ParseBool(os.Getenv("SSK_SERVER_ONLY")) // default is false
-	if diff := cmp.Diff(ssk.Env{
+	if diff := cmp.Diff(&ssk.Env{
 		ServerAddr: os.Getenv("SSK_SERVER_ADDR"),
 		Command:    os.Getenv("SSK_COMMAND"),
 		KMSKeyID:   os.Getenv("SAKURACLOUD_KMS_KEY_ID"),
@@ -39,13 +36,11 @@ func TestParseEnv(t *testing.T) {
 }
 
 func TestParseEnvDefault(t *testing.T) {
-	var e ssk.Env
-	k, err := kong.New(&e)
+	e, err := ssk.LoadEnv()
 	if err != nil {
-		t.Fatalf("failed to create parser: %v", err)
+		t.Fatalf("failed to load environment variables: %v", err)
 	}
-	k.Parse([]string{})
-	if diff := cmp.Diff(ssk.Env{
+	if diff := cmp.Diff(&ssk.Env{
 		ServerAddr: "127.0.0.1:8200",
 		Command:    "sops",
 		KMSKeyID:   os.Getenv("SAKURACLOUD_KMS_KEY_ID"),
@@ -53,4 +48,61 @@ func TestParseEnvDefault(t *testing.T) {
 	}, e); diff != "" {
 		t.Errorf("parsed env mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func TestLoadEnv(t *testing.T) {
+	t.Run("all values from environment", func(t *testing.T) {
+		for k, v := range envSet {
+			t.Setenv(k, v)
+		}
+
+		env, err := ssk.LoadEnv()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		serverOnly, _ := strconv.ParseBool(envSet["SSK_SERVER_ONLY"])
+		if diff := cmp.Diff(&ssk.Env{
+			KMSKeyID:   envSet["SAKURACLOUD_KMS_KEY_ID"],
+			ServerOnly: serverOnly,
+			ServerAddr: envSet["SSK_SERVER_ADDR"],
+			Command:    envSet["SSK_COMMAND"],
+		}, env); diff != "" {
+			t.Errorf("LoadEnv mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("default values", func(t *testing.T) {
+		t.Setenv("SAKURACLOUD_KMS_KEY_ID", "test-key-id")
+
+		env, err := ssk.LoadEnv()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if diff := cmp.Diff(&ssk.Env{
+			KMSKeyID:   "test-key-id",
+			ServerOnly: false,
+			ServerAddr: "127.0.0.1:8200",
+			Command:    "sops",
+		}, env); diff != "" {
+			t.Errorf("LoadEnv mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("required field missing", func(t *testing.T) {
+		t.Setenv("SAKURACLOUD_KMS_KEY_ID", "")
+		_, err := ssk.LoadEnv()
+		if err == nil {
+			t.Fatal("expected error for missing required field, got nil")
+		}
+	})
+
+	t.Run("invalid boolean value", func(t *testing.T) {
+		t.Setenv("SAKURACLOUD_KMS_KEY_ID", "test-key-id")
+		t.Setenv("SSK_SERVER_ONLY", "invalid")
+
+		_, err := ssk.LoadEnv()
+		if err == nil {
+			t.Fatal("expected error for invalid boolean value, got nil")
+		}
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fujiwara/sops-sakura-kms
 go 1.24.0
 
 require (
-	github.com/alecthomas/kong v1.13.0
+	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/vault/api v1.22.0
 	github.com/sacloud/kms-api-go v0.3.0
 	golang.org/x/sys v0.37.0
@@ -19,7 +19,6 @@ require (
 	github.com/go-faster/jx v1.1.0 // indirect
 	github.com/go-faster/yaml v0.4.6 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.1 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,3 @@
-github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
-github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/kong v1.13.0 h1:5e/7XC3ugvhP1DQBmTS+WuHtCbcv44hsohMgcvVxSrA=
-github.com/alecthomas/kong v1.13.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
-github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
-github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -53,8 +47,6 @@ github.com/hashicorp/hcl v1.0.1-vault-7 h1:ag5OxFVy3QYTFTJODRzTKVZ6xvdfLLCA1cy/Y
 github.com/hashicorp/hcl v1.0.1-vault-7/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.22.0 h1:+HYFquE35/B74fHoIeXlZIP2YADVboaPjaSicHEZiH0=
 github.com/hashicorp/vault/api v1.22.0/go.mod h1:IUZA2cDvr4Ok3+NtK2Oq/r+lJeXkeCrHRmqdyWfpmGM=
-github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
-github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/main.go
+++ b/main.go
@@ -11,8 +11,6 @@ import (
 	"os/exec"
 	"strings"
 	"time"
-
-	"github.com/alecthomas/kong"
 )
 
 const (
@@ -43,13 +41,9 @@ func newServer(cipher Cipher, addr string) *http.Server {
 // It automatically configures SOPS to use Sakura Cloud KMS via SOPS_VAULT_URIS environment variable.
 // Requires SAKURA_KMS_KEY_ID environment variable to be set.
 func RunWrapper(ctx context.Context, args []string) error {
-	e := &Env{}
-	k, err := kong.New(e)
+	e, err := LoadEnv()
 	if err != nil {
-		return fmt.Errorf("failed to create parser: %w", err)
-	}
-	if _, err := k.Parse([]string{}); err != nil { // parse from environment only(not from args)
-		return fmt.Errorf("failed to parse command-line arguments: %w", err)
+		return fmt.Errorf("failed to load environment variables: %w", err)
 	}
 	slog.Debug("Parsed command-line arguments", "env", e)
 


### PR DESCRIPTION
## Summary
- Implement `LoadEnv()` function that reads struct tags (`env`, `default`, `required`) to parse environment variables
- Remove dependency on `github.com/alecthomas/kong`

🤖 Generated with [Claude Code](https://claude.com/claude-code)