### PR TITLE
Preserve exit code from wrapped command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ sops-sakura-kms secrets.enc.yaml
 4. Executes SOPS with the configured environment
 5. The server handles encryption/decryption requests from SOPS using Sakura Cloud KMS
 
+### Exit Code
+
+`sops-sakura-kms` preserves the exit code from the wrapped command (SOPS or custom command specified by `SSK_COMMAND`).
+
+- If the wrapped command exits with code N, `sops-sakura-kms` also exits with code N
+- If an error occurs before executing the wrapped command (e.g., missing environment variables, server startup failure), `sops-sakura-kms` exits with code 1
+
 ### SOPS Configuration
 
 You can use the standard SOPS configuration file (`.sops.yaml`) without specifying the `hc_vault_transit_uri`:

--- a/cmd/sops-sakura-kms/main.go
+++ b/cmd/sops-sakura-kms/main.go
@@ -13,13 +13,14 @@ import (
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), signals()...)
 	defer stop()
-	if err := run(ctx); err != nil {
+	exitCode, err := run(ctx)
+	if err != nil {
 		slog.Error(err.Error())
-		os.Exit(1)
 	}
+	os.Exit(exitCode)
 }
 
-func run(ctx context.Context) error {
+func run(ctx context.Context) (int, error) {
 	args := os.Args[1:]
 
 	// Handle --version flag
@@ -27,7 +28,7 @@ func run(ctx context.Context) error {
 	for _, arg := range args {
 		if arg == "--version" || arg == "-version" {
 			fmt.Printf("sops-sakura-kms version %s\n", app.Version)
-			return nil
+			return 0, nil
 		}
 		newArgs = append(newArgs, arg)
 	}

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -1,0 +1,69 @@
+package ssk_test
+
+import (
+	"context"
+	"testing"
+
+	ssk "github.com/fujiwara/sops-sakura-kms"
+)
+
+func TestRunWrapperExitCode(t *testing.T) {
+	tests := []struct {
+		name         string
+		command      string
+		args         []string
+		wantExitCode int
+	}{
+		{
+			name:         "exit 0",
+			command:      "sh",
+			args:         []string{"-c", "exit 0"},
+			wantExitCode: 0,
+		},
+		{
+			name:         "exit 1",
+			command:      "sh",
+			args:         []string{"-c", "exit 1"},
+			wantExitCode: 1,
+		},
+		{
+			name:         "exit 2",
+			command:      "sh",
+			args:         []string{"-c", "exit 2"},
+			wantExitCode: 2,
+		},
+		{
+			name:         "exit 42",
+			command:      "sh",
+			args:         []string{"-c", "exit 42"},
+			wantExitCode: 42,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SAKURACLOUD_KMS_KEY_ID", "test-key-id")
+			t.Setenv("SSK_COMMAND", tt.command)
+
+			exitCode, err := ssk.RunWrapper(context.Background(), tt.args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if exitCode != tt.wantExitCode {
+				t.Errorf("exitCode = %d, want %d", exitCode, tt.wantExitCode)
+			}
+		})
+	}
+}
+
+func TestRunWrapperMissingKeyID(t *testing.T) {
+	t.Setenv("SAKURACLOUD_KMS_KEY_ID", "")
+
+	exitCode, err := ssk.RunWrapper(context.Background(), []string{})
+	if err == nil {
+		t.Fatal("expected error for missing key ID, got nil")
+	}
+	if exitCode != ssk.ExitCodeError {
+		t.Errorf("exitCode = %d, want %d", exitCode, ssk.ExitCodeError)
+	}
+}


### PR DESCRIPTION
## Summary
- Change `RunWrapper` to return `(int, error)` instead of `error`
- Define `ExitCodeError` constant for application errors
- Add tests for exit code handling
- Document exit code behavior in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)