### PR TITLE
Support SAKURA_KMS_KEY_ID env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ You can use the provided container image: [`ghcr.io/fujiwara/sops-sakura-kms`](h
 
 ```console
 $ docker run --rm \
-    -e SAKURACLOUD_ACCESS_TOKEN \
-    -e SAKURACLOUD_ACCESS_TOKEN_SECRET \
-    -e SAKURACLOUD_KMS_KEY_ID \
+    -e SAKURA_ACCESS_TOKEN \
+    -e SAKURA_ACCESS_TOKEN_SECRET \
+    -e SAKURA_KMS_KEY_ID \
     -v $(pwd):/work -w /work \
     ghcr.io/fujiwara/sops-sakura-kms:v0.0.7 \
     -d secrets.enc.yaml
@@ -74,12 +74,20 @@ Set the following environment variables:
 
 ```bash
 # Sakura Cloud API credentials
-export SAKURACLOUD_ACCESS_TOKEN="your-access-token"
-export SAKURACLOUD_ACCESS_TOKEN_SECRET="your-access-token-secret"
+export SAKURA_ACCESS_TOKEN="your-access-token"
+export SAKURA_ACCESS_TOKEN_SECRET="your-access-token-secret"
 
 # Sakura Cloud KMS Resource ID (12-digit number as string, e.g., 123456789012)
-export SAKURACLOUD_KMS_KEY_ID="123456789012"
+export SAKURA_KMS_KEY_ID="123456789012"
 ```
+
+**Note:** For backward compatibility, the following alternative environment variable names are also supported. If both are set, `SAKURA_*` takes priority.
+
+| Primary (Recommended) | Alternative |
+|----------------------|-------------|
+| `SAKURA_ACCESS_TOKEN` | `SAKURACLOUD_ACCESS_TOKEN` |
+| `SAKURA_ACCESS_TOKEN_SECRET` | `SAKURACLOUD_ACCESS_TOKEN_SECRET` |
+| `SAKURA_KMS_KEY_ID` | `SAKURACLOUD_KMS_KEY_ID` |
 
 ### Optional Environment Variables
 
@@ -246,7 +254,7 @@ func main() {
 	ctx := context.Background()
 
 	// Start Vault Transit Engine compatible server
-	addEnv, shutdown, err := ssk.RunServer(ctx, "127.0.0.1:8200", os.Getenv("SAKURACLOUD_KMS_KEY_ID"))
+	addEnv, shutdown, err := ssk.RunServer(ctx, "127.0.0.1:8200", os.Getenv("SAKURA_KMS_KEY_ID"))
 	if err != nil {
 		panic(err)
 	}
@@ -287,7 +295,7 @@ func RunServer(ctx context.Context, addr, keyID string) (map[string]string, func
 - `func(context.Context) error`: Shutdown function to stop the server
 - `error`: Any error that occurred during startup
 
-**Note:** Sakura Cloud API credentials (`SAKURACLOUD_ACCESS_TOKEN`, `SAKURACLOUD_ACCESS_TOKEN_SECRET`) must be set in environment variables before calling `RunServer`.
+**Note:** Sakura Cloud API credentials (`SAKURA_ACCESS_TOKEN`, `SAKURA_ACCESS_TOKEN_SECRET`) must be set in environment variables before calling `RunServer`.
 
 ## Development
 

--- a/env_test.go
+++ b/env_test.go
@@ -114,4 +114,29 @@ func TestLoadEnv(t *testing.T) {
 			t.Fatal("expected error for invalid boolean value, got nil")
 		}
 	})
+
+	t.Run("SAKURA_KMS_KEY_ID only", func(t *testing.T) {
+		t.Setenv("SAKURA_KMS_KEY_ID", "sakura-key-id")
+
+		env, err := ssk.LoadEnv()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if env.KMSKeyID != "sakura-key-id" {
+			t.Errorf("KMSKeyID = %q, want %q", env.KMSKeyID, "sakura-key-id")
+		}
+	})
+
+	t.Run("SAKURA_KMS_KEY_ID takes priority over SAKURACLOUD_KMS_KEY_ID", func(t *testing.T) {
+		t.Setenv("SAKURA_KMS_KEY_ID", "sakura-key-id")
+		t.Setenv("SAKURACLOUD_KMS_KEY_ID", "sakuracloud-key-id")
+
+		env, err := ssk.LoadEnv()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if env.KMSKeyID != "sakura-key-id" {
+			t.Errorf("KMSKeyID = %q, want %q (SAKURA_KMS_KEY_ID should take priority)", env.KMSKeyID, "sakura-key-id")
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Add support for `SAKURA_KMS_KEY_ID` environment variable alongside existing `SAKURACLOUD_KMS_KEY_ID`
- `SAKURA_*` prefix takes priority when both are set
- Update README to document the new environment variable names

## Test plan
- [x] Added unit tests for new env var priority logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)