### PR TITLE
fix --version output

### DIFF
--- a/cmd/sops-sakura-kms/main.go
+++ b/cmd/sops-sakura-kms/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -27,8 +26,7 @@ func run(ctx context.Context) (int, error) {
 	newArgs := make([]string, 0, len(args))
 	for _, arg := range args {
 		if arg == "--version" || arg == "-version" {
-			fmt.Printf("sops-sakura-kms version %s\n", app.Version)
-			return 0, nil
+			return app.ShowVersion(ctx, os.Stdout)
 		}
 		newArgs = append(newArgs, arg)
 	}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,29 @@
 package ssk
 
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
 var Version = "v0.3.0"
+
+func ShowVersion(ctx context.Context, w io.Writer) (int, error) {
+	// Ensure self Version is printed even if error occurs later
+	defer fmt.Fprintf(w, "sops-sakura-kms version %s\n", Version)
+
+	os.Setenv("SAKURA_KMS_KEY_ID", "dummy") // dummy value to pass LoadEnv
+	env, err := LoadEnv()
+	if err != nil {
+		return ExitCodeError, fmt.Errorf("failed to load environment variables: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, env.Command, "--version", "--disable-version-check")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return ExitCodeError, fmt.Errorf("failed to execute %s --version: %w", env.Command, err)
+	}
+	w.Write(output)
+	return 0, nil
+}


### PR DESCRIPTION
shows with sops --version

```console
$ sops-sakura-kms --version
sops 3.11.0
sops-sakura-kms version v0.3.0
```

[Anaible community.sops](https://galaxy.ansible.com/ui/repo/published/community/sops/) requires `sops x.x.x` outputs for version parsing.
https://github.com/ansible-collections/community.sops/blob/fa6c7afc590f4ab658d7ab81163abb3448b74fd5/plugins/module_utils/sops.py#L174C80-L182
If it is not expected, show a warning.