### PR TITLE
Make SAKURA_KMS_KEY_ID optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ export SAKURA_ACCESS_TOKEN="your-access-token"
 export SAKURA_ACCESS_TOKEN_SECRET="your-access-token-secret"
 
 # Sakura Cloud KMS Resource ID (12-digit number as string, e.g., 123456789012)
+# Required for encryption when hc_vault_transit_uri is not configured in .sops.yaml
+# Not required for decryption (the key ID is stored in the encrypted file)
 export SAKURA_KMS_KEY_ID="123456789012"
 ```
 
@@ -122,8 +124,8 @@ sops-sakura-kms secrets.enc.yaml
 ### How it works
 
 1. `sops-sakura-kms` starts a local Vault Transit Engine compatible HTTP server on `127.0.0.1:8200`
-2. Automatically sets the `SOPS_VAULT_URIS` environment variable to `http://127.0.0.1:8200/v1/transit/encrypt/{key_id}`
-3. Sets required environment variables (`VAULT_ADDR`, `VAULT_TOKEN`)
+2. Sets required environment variables (`VAULT_ADDR`, `VAULT_TOKEN`)
+3. If `SAKURA_KMS_KEY_ID` is set, automatically sets the `SOPS_VAULT_URIS` environment variable to `http://127.0.0.1:8200/v1/transit/encrypt/{key_id}`
 4. Executes SOPS with the configured environment
 5. The server handles encryption/decryption requests from SOPS using Sakura Cloud KMS
 
@@ -132,7 +134,7 @@ sops-sakura-kms secrets.enc.yaml
 `sops-sakura-kms` preserves the exit code from the wrapped command (SOPS or custom command specified by `SSK_COMMAND`).
 
 - If the wrapped command exits with code N, `sops-sakura-kms` also exits with code N
-- If an error occurs before executing the wrapped command (e.g., missing environment variables, server startup failure), `sops-sakura-kms` exits with code 1
+- If an error occurs before executing the wrapped command (e.g., server startup failure), `sops-sakura-kms` exits with code 1
 
 ### SOPS Configuration
 
@@ -312,7 +314,7 @@ func RunServer(ctx context.Context, addr, keyID string, opts ...Option) (map[str
   - `WithCipher(Cipher)`: Use a custom Cipher implementation (for testing)
 
 **Returns:**
-- `map[string]string`: Environment variables for SOPS (`VAULT_ADDR`, `VAULT_TOKEN`, `SOPS_VAULT_URIS`)
+- `map[string]string`: Environment variables for SOPS (`VAULT_ADDR`, `VAULT_TOKEN`, and `SOPS_VAULT_URIS` if `keyID` is non-empty)
 - `func(context.Context) error`: Shutdown function to stop the server
 - `error`: Any error that occurred during startup
 

--- a/env.go
+++ b/env.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Env struct {
-	KMSKeyID   string `env:"SAKURA_KMS_KEY_ID,SAKURACLOUD_KMS_KEY_ID" required:""`
+	KMSKeyID   string `env:"SAKURA_KMS_KEY_ID,SAKURACLOUD_KMS_KEY_ID"`
 	ServerOnly bool   `env:"SSK_SERVER_ONLY" default:"false"`
 	ServerAddr string `env:"SSK_SERVER_ADDR" default:"127.0.0.1:8200"`
 	Command    string `env:"SSK_COMMAND" default:"sops"`

--- a/env_test.go
+++ b/env_test.go
@@ -51,11 +51,14 @@ func TestParseEnvDefault(t *testing.T) {
 	}
 }
 
-func TestParseEnvRequired(t *testing.T) {
+func TestParseEnvEmptyKeyID(t *testing.T) {
 	t.Setenv("SAKURACLOUD_KMS_KEY_ID", "")
-	_, err := ssk.LoadEnv()
-	if err == nil {
-		t.Fatal("expected error for missing required field, got nil")
+	e, err := ssk.LoadEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if e.KMSKeyID != "" {
+		t.Errorf("KMSKeyID = %q, want empty", e.KMSKeyID)
 	}
 }
 
@@ -97,11 +100,14 @@ func TestLoadEnv(t *testing.T) {
 		}
 	})
 
-	t.Run("required field missing", func(t *testing.T) {
+	t.Run("empty key ID", func(t *testing.T) {
 		t.Setenv("SAKURACLOUD_KMS_KEY_ID", "")
-		_, err := ssk.LoadEnv()
-		if err == nil {
-			t.Fatal("expected error for missing required field, got nil")
+		env, err := ssk.LoadEnv()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if env.KMSKeyID != "" {
+			t.Errorf("KMSKeyID = %q, want empty", env.KMSKeyID)
 		}
 	})
 

--- a/main.go
+++ b/main.go
@@ -82,6 +82,9 @@ func RunWrapper(ctx context.Context, args []string) (int, error) {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
+		if e.KMSKeyID == "" {
+			slog.Warn("command exited with error. If you need to encrypt, set SAKURA_KMS_KEY_ID or configure hc_vault_transit_uri in .sops.yaml")
+		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			return exitErr.ExitCode(), nil
@@ -153,11 +156,12 @@ func runServer(ctx context.Context, addr, keyID string, cipher Cipher) (map[stri
 		return nil, nil, fmt.Errorf("failed to start server: %w", err)
 	}
 
-	vaultTransitURI := fmt.Sprintf("http://%s/v1/transit/encrypt/%s", addr, keyID)
 	env := map[string]string{
-		"VAULT_ADDR":      "http://" + addr,
-		"VAULT_TOKEN":     "dummy",
-		"SOPS_VAULT_URIS": vaultTransitURI,
+		"VAULT_ADDR":  "http://" + addr,
+		"VAULT_TOKEN": "dummy",
+	}
+	if keyID != "" {
+		env["SOPS_VAULT_URIS"] = fmt.Sprintf("http://%s/v1/transit/encrypt/%s", addr, keyID)
 	}
 	return env, server.Shutdown, nil
 }

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -56,14 +56,27 @@ func TestRunWrapperExitCode(t *testing.T) {
 	}
 }
 
-func TestRunWrapperMissingKeyID(t *testing.T) {
+func TestRunWrapperEmptyKeyID(t *testing.T) {
 	t.Setenv("SAKURACLOUD_KMS_KEY_ID", "")
+	t.Setenv("SSK_COMMAND", "sh")
 
-	exitCode, err := ssk.RunWrapper(context.Background(), []string{})
-	if err == nil {
-		t.Fatal("expected error for missing key ID, got nil")
-	}
-	if exitCode != ssk.ExitCodeError {
-		t.Errorf("exitCode = %d, want %d", exitCode, ssk.ExitCodeError)
-	}
+	t.Run("success without key ID", func(t *testing.T) {
+		exitCode, err := ssk.RunWrapper(context.Background(), []string{"-c", "exit 0"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if exitCode != 0 {
+			t.Errorf("exitCode = %d, want 0", exitCode)
+		}
+	})
+
+	t.Run("error without key ID", func(t *testing.T) {
+		exitCode, err := ssk.RunWrapper(context.Background(), []string{"-c", "exit 1"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if exitCode != 1 {
+			t.Errorf("exitCode = %d, want 1", exitCode)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Make `SAKURA_KMS_KEY_ID` optional instead of required
- When not set, the server starts normally but `SOPS_VAULT_URIS` is not configured
- If the wrapped command exits with error and key ID is empty, log a warning hint suggesting to set `SAKURA_KMS_KEY_ID` or configure `hc_vault_transit_uri` in `.sops.yaml`

## Why
The key ID is only needed to set `SOPS_VAULT_URIS` for encryption when `hc_vault_transit_uri` is not configured in `.sops.yaml`. For decryption, the key ID is already embedded in the encrypted file as part of the Vault Transit URI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)