### PR TITLE
Update Go to 1.26 in CI and Dockerfile

### DIFF
--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
         if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.25"
+          - "1.26"
     name: Build
     runs-on: ubuntu-latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.25 AS build-env
+FROM --platform=${BUILDPLATFORM} golang:1.26 AS build-env
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Summary
- Update Go version from 1.25 to 1.26 in CI workflows and Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)