### PR TITLE
Improve signal handling for sops exec-env and editor sub-processes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.25.0
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/vault/api v1.22.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/sacloud/kms-api-go v0.4.0
+	github.com/sacloud/saclient-go v0.3.1
 	golang.org/x/sys v0.41.0
 )
 
@@ -32,7 +34,6 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/ogen-go/ogen v1.15.1 // indirect
@@ -40,7 +41,6 @@ require (
 	github.com/sacloud/api-client-go v0.3.5 // indirect
 	github.com/sacloud/go-http v0.1.9 // indirect
 	github.com/sacloud/packages-go v0.0.12 // indirect
-	github.com/sacloud/saclient-go v0.3.1 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect

--- a/main.go
+++ b/main.go
@@ -10,9 +10,12 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
+	"syscall"
 	"time"
 
+	"github.com/mattn/go-isatty"
 	"github.com/sacloud/saclient-go"
 )
 
@@ -23,6 +26,13 @@ const (
 	// ExitCodeError is the exit code returned when an error occurs in the application.
 	ExitCodeError = 1
 )
+
+// IsStdinTerminal reports whether stdin is a terminal. It is a
+// package variable so tests can substitute their own check; production
+// callers should leave it alone.
+var IsStdinTerminal = func() bool {
+	return isatty.IsTerminal(os.Stdin.Fd())
+}
 
 // NewMux creates a new HTTP ServeMux with Vault Transit Engine compatible API endpoints.
 func NewMux(cipher Cipher) *http.ServeMux {
@@ -71,8 +81,30 @@ func RunWrapper(ctx context.Context, args []string) (int, error) {
 
 	slog.Info("Server started successfully, executing", "command", e.Command, "args", args)
 
-	// Execute command
-	cmd := exec.CommandContext(ctx, e.Command, args...)
+	// Execute command. `sops exec-env` from a tty typically launches an
+	// interactive program (mysql cli, editor, ...) that wants to handle
+	// Ctrl-C on its own — and possibly receive many of them. SIGINT
+	// reaches the child via the foreground process group, so we must
+	// not pass ctx to exec there (CommandContext would SIGKILL the
+	// child the moment our own ctx is cancelled by the inherited
+	// SIGINT).
+	//
+	// Everywhere else we keep exec.CommandContext but override its
+	// Cancel to send SIGTERM rather than the default SIGKILL, with a
+	// short WaitDelay as the SIGKILL escalation grace period. This
+	// lets the child (sops itself, an editor under `sops -i`, a batch
+	// process under non-tty `exec-env`, ...) clean up before exiting.
+	isExecEnv := slices.Contains(args, "exec-env")
+	var cmd *exec.Cmd
+	if isExecEnv && IsStdinTerminal() {
+		cmd = exec.Command(e.Command, args...)
+	} else {
+		cmd = exec.CommandContext(ctx, e.Command, args...)
+		cmd.Cancel = func() error {
+			return cmd.Process.Signal(syscall.SIGTERM)
+		}
+		cmd.WaitDelay = 5 * time.Second
+	}
 	cmd.Env = os.Environ()
 	for k, v := range addEnv {
 		cmd.Env = append(cmd.Env, k+"="+v)

--- a/signal_test.go
+++ b/signal_test.go
@@ -1,0 +1,168 @@
+package ssk_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	ssk "github.com/fujiwara/sops-sakura-kms"
+)
+
+// TestMain lets this test binary double as a wrapper helper. When
+// SSK_TEST_HELPER=1 is set, the binary runs RunWrapper instead of the
+// test suite so the signal tests can drive it as a real subprocess.
+// SSK_TEST_TTY=1 makes RunWrapper see stdin as a terminal regardless
+// of how the helper was launched.
+func TestMain(m *testing.M) {
+	if os.Getenv("SSK_TEST_HELPER") == "1" {
+		ttyForced := os.Getenv("SSK_TEST_TTY") == "1"
+		ssk.IsStdinTerminal = func() bool { return ttyForced }
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		args := strings.Split(os.Getenv("SSK_TEST_ARGS"), "\x1f")
+		exitCode, _ := ssk.RunWrapper(ctx, args)
+		os.Exit(exitCode)
+	}
+	os.Exit(m.Run())
+}
+
+func startWrapperHelper(t *testing.T, addr, args string, tty bool) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0])
+	env := append(os.Environ(),
+		"SSK_TEST_HELPER=1",
+		"SSK_TEST_ARGS="+args,
+		"SAKURACLOUD_KMS_KEY_ID=test-key-id",
+		"SSK_COMMAND=sh",
+		"SSK_SERVER_ADDR="+addr,
+	)
+	if tty {
+		env = append(env, "SSK_TEST_TTY=1")
+	}
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start helper: %v", err)
+	}
+	return cmd
+}
+
+func waitWithTimeout(t *testing.T, cmd *exec.Cmd, d time.Duration) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(d):
+		_ = cmd.Process.Kill()
+		<-done
+		t.Fatalf("wrapper did not exit within %s", d)
+		return nil
+	}
+}
+
+// TestRunWrapperExecEnvLetsChildExitOnItsOwn verifies that for the
+// `exec-env` subcommand running in a tty, the wrapper does not kill
+// the child when the wrapper itself receives SIGINT. Interactive
+// children (e.g. mysql cli) need to decide for themselves whether and
+// when to exit on Ctrl-C, and may legitimately accept many of them.
+// We send SIGINT to the wrapper a few times while the child runs and
+// then verify the wrapper propagates the child's own exit code.
+func TestRunWrapperExecEnvLetsChildExitOnItsOwn(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("signal tests are unix-only")
+	}
+	// Args = ["-c", "echo READY; sleep 2; exit 42", "exec-env"]. The
+	// trailing "exec-env" is what makes RunWrapper take the
+	// no-context path; sh treats it as $0 and ignores it. tty=true
+	// satisfies the second gating condition.
+	cmd := startWrapperHelper(t, "127.0.0.1:18301",
+		"-c\x1fecho READY; sleep 2; exit 42\x1fexec-env", true)
+
+	time.Sleep(1500 * time.Millisecond)
+	for range 3 {
+		if err := cmd.Process.Signal(syscall.SIGINT); err != nil {
+			t.Fatalf("send SIGINT: %v", err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	err := waitWithTimeout(t, cmd, 10*time.Second)
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError from helper, got %v", err)
+	}
+	if got := exitErr.ExitCode(); got != 42 {
+		t.Errorf("exit code = %d, want 42 (child exited on its own)", got)
+	}
+}
+
+// TestRunWrapperExecEnvNonTTYForwardsSIGTERM verifies that for
+// `exec-env` running outside a tty (typical orchestrator setup —
+// systemd, k8s, CI), the wrapper forwards SIGTERM to the child via
+// exec.Cmd.Cancel rather than the default SIGKILL. This gives the
+// child a chance to shut down cleanly.
+func TestRunWrapperExecEnvNonTTYForwardsSIGTERM(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("signal tests are unix-only")
+	}
+	// Child traps SIGTERM, kills its background sleep, and exits 17.
+	// Without forwarding the child would be SIGKILLed and exit
+	// non-zero with a signal-status exit code, not 17.
+	cmd := startWrapperHelper(t, "127.0.0.1:18303",
+		"-c\x1ftrap 'kill $! 2>/dev/null; exit 17' TERM; echo READY; sleep 30 & wait\x1fexec-env",
+		false)
+
+	time.Sleep(1500 * time.Millisecond)
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+
+	err := waitWithTimeout(t, cmd, 5*time.Second)
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError from helper, got %v", err)
+	}
+	if got := exitErr.ExitCode(); got != 17 {
+		t.Errorf("exit code = %d, want 17 (child SIGTERM trap fired)", got)
+	}
+}
+
+// TestRunWrapperNonExecEnvForwardsSIGTERM verifies that for non
+// `exec-env` subcommands (e.g. `sops -i` which spawns an editor),
+// SIGTERM is forwarded to the child via exec.Cmd.Cancel so the child
+// has a chance to clean up before exiting.
+func TestRunWrapperNonExecEnvForwardsSIGTERM(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("signal tests are unix-only")
+	}
+	// Child traps SIGTERM, kills its background sleep, and exits 17.
+	// If the wrapper SIGKILLed the child instead, the trap could not
+	// fire and we'd see a signal-status exit code.
+	cmd := startWrapperHelper(t, "127.0.0.1:18302",
+		"-c\x1ftrap 'kill $! 2>/dev/null; exit 17' TERM; echo READY; sleep 30 & wait",
+		false)
+
+	time.Sleep(1500 * time.Millisecond)
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+
+	err := waitWithTimeout(t, cmd, 5*time.Second)
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError from helper, got %v", err)
+	}
+	if got := exitErr.ExitCode(); got != 17 {
+		t.Errorf("exit code = %d, want 17 (child SIGTERM trap fired)", got)
+	}
+}


### PR DESCRIPTION
## Summary

`exec.CommandContext` SIGKILLs the wrapped child as soon as the wrapper's own context is cancelled by a signal. That makes two scenarios unpleasant:

- Interactive `sops exec-env` (e.g. dropping into `mysql` cli): a single Ctrl-C in the terminal kills the wrapped tool outright, instead of letting it handle the signal itself — many CLIs intentionally absorb multiple Ctrl-Cs.
- SIGTERM from systemd/k8s/etc.: no wrapped sub-process (sops itself, an editor under `sops -i`, a batch process under non-tty `exec-env`) gets a chance to clean up.

## Changes

Split the exec handling into two paths:

- **tty + `exec-env`**: use `exec.Command` (no context). The foreground process group delivers SIGINT to the child and the wrapper stays out of the way.
- **Everywhere else**: keep `exec.CommandContext` but override `cmd.Cancel` to send SIGTERM instead of the default SIGKILL, with `cmd.WaitDelay=5s` as the SIGKILL escalation grace period.

`tty` is detected via `isatty.IsTerminal(os.Stdin.Fd())`. The check is exposed as a package variable `IsStdinTerminal` so tests can substitute it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)